### PR TITLE
Cognito integration

### DIFF
--- a/pennsieve/api/agent.py
+++ b/pennsieve/api/agent.py
@@ -112,8 +112,7 @@ class AgentListener(object):
 
     def __enter__(self):
         check_port(self.port)
-        command = [agent_cmd(), "upload-status", "--listen",
-                   "--port", str(self.port)]
+        command = [agent_cmd(), "upload-status", "--listen", "--port", str(self.port)]
 
         self.devnull = open(os.devnull, "w")
         self.proc = subprocess.Popen(
@@ -166,8 +165,7 @@ def create_agent_socket(port):
         except socket.error as e:
             if e.errno == errno.ECONNREFUSED:  # ConnectionRefusedError for Python 3
                 sleep_time = 2 ** i
-                logger.debug(
-                    "Connection refused - sleeping for %s seconds", sleep_time)
+                logger.debug("Connection refused - sleeping for %s seconds", sleep_time)
                 sleep(sleep_time)
             else:
                 raise
@@ -228,8 +226,7 @@ def agent_upload(
         dataset_id = dataset.id
         package_id = destination.id
     else:
-        raise ValueError(
-            "Can only upload to a Dataset, Package, or Collection")
+        raise ValueError("Can only upload to a Dataset, Package, or Collection")
 
     with AgentListener(settings, DEFAULT_LISTEN_PORT):
         try:
@@ -289,7 +286,7 @@ def agent_upload(
 
 
 def remove_prefix(text, prefix):
-    return text[text.startswith(prefix) and len(prefix):]
+    return text[text.startswith(prefix) and len(prefix) :]
 
 
 class UploadManager(object):

--- a/pennsieve/api/agent.py
+++ b/pennsieve/api/agent.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError:
     )
 
 
-MINIMUM_AGENT_VERSION = semver.parse_version_info("0.2.100")
+MINIMUM_AGENT_VERSION = semver.VersionInfo.parse("0.2.100")
 DEFAULT_LISTEN_PORT = 11235
 
 
@@ -112,7 +112,8 @@ class AgentListener(object):
 
     def __enter__(self):
         check_port(self.port)
-        command = [agent_cmd(), "upload-status", "--listen", "--port", str(self.port)]
+        command = [agent_cmd(), "upload-status", "--listen",
+                   "--port", str(self.port)]
 
         self.devnull = open(os.devnull, "w")
         self.proc = subprocess.Popen(
@@ -165,7 +166,8 @@ def create_agent_socket(port):
         except socket.error as e:
             if e.errno == errno.ECONNREFUSED:  # ConnectionRefusedError for Python 3
                 sleep_time = 2 ** i
-                logger.debug("Connection refused - sleeping for %s seconds", sleep_time)
+                logger.debug(
+                    "Connection refused - sleeping for %s seconds", sleep_time)
                 sleep(sleep_time)
             else:
                 raise
@@ -226,7 +228,8 @@ def agent_upload(
         dataset_id = dataset.id
         package_id = destination.id
     else:
-        raise ValueError("Can only upload to a Dataset, Package, or Collection")
+        raise ValueError(
+            "Can only upload to a Dataset, Package, or Collection")
 
     with AgentListener(settings, DEFAULT_LISTEN_PORT):
         try:
@@ -286,7 +289,7 @@ def agent_upload(
 
 
 def remove_prefix(text, prefix):
-    return text[text.startswith(prefix) and len(prefix) :]
+    return text[text.startswith(prefix) and len(prefix):]
 
 
 class UploadManager(object):

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -46,7 +46,8 @@ class PennsieveRequest(object):
 
     def _handle_response(self, resp):
         self._logger.debug(u"resp = {}".format(resp))
-        self._logger.debug(u"resp.content = {}".format(resp.text))  # decoded unicode
+        self._logger.debug(u"resp.content = {}".format(
+            resp.text))  # decoded unicode
         if resp.status_code in [requests.codes.forbidden, requests.codes.unauthorized]:
             raise UnauthorizedException()
 
@@ -100,43 +101,18 @@ class ClientSession(object):
         subsequent API calls.
         """
 
-        # Get the latest public jwks for our user pool
-        #
-        # TODO(jesse) These keys are used to verify the JWT
-        #
-        # region = "us-east-1"
-        # userpool_id = "us-east-1_7bX2Pm0zh"
-        # jwks_url = 'https://cognito-idp.{}.amazonaws.com/{}/.well-known/jwks.json'.format(region, userpool_id)
-        # jwks = requests.get(jwks_url).json()["keys"]
-
         # Make authentication request to AWS Cognito
         cognito_idp_client = boto3.client("cognito-idp")
         response = cognito_idp_client.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",
-            AuthParameters={"USERNAME": self._api_token, "PASSWORD": self._api_secret},
+            AuthParameters={"USERNAME": self._api_token,
+                            "PASSWORD": self._api_secret},
             ClientId=self._api_id,
         )
 
         # Grab the tokens
         access_token_jwt = response["AuthenticationResult"]["AccessToken"]
         id_token_jwt = response["AuthenticationResult"]["IdToken"]
-
-        # Verify the token signatures
-        #
-        # TODO(jesse) Figure out why this check fails.
-        #
-        # Search for the kid in the downloaded public keys
-        #
-        # headers = jwt.get_unverified_headers(id_token_jwt)
-        # kid = headers["kid"]
-        # key_index = list(map(lambda jwk: jwk["kid"], jwks)).index(kid)
-        # public_key = jwk.construct(jwks[key_index])
-        #
-        # for token in [access_token_jwt, id_token_jwt]:
-        #     message, encoded_signature = str(token).rsplit('.', 1)
-        #     decoded_signature = base64url_decode(encoded_signature.encode('utf-8'))
-        #     if not public_key.verify(message.encode("utf8"), decoded_signature):
-        #         raise ValueError("Signature verification failed")
 
         # Since we passed the verification, we can now safely use the claims
         claims = jwt.get_unverified_claims(id_token_jwt)
@@ -181,7 +157,8 @@ class ClientSession(object):
         self._session.headers["X-ORGANIZATION-ID"] = organization_id
 
     def _set_auth(self, session_token):
-        self._session.headers["Authorization"] = "Bearer {}".format(session_token)
+        self._session.headers["Authorization"] = "Bearer {}".format(
+            session_token)
 
     @property
     def session(self):

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -103,7 +103,7 @@ class ClientSession(object):
         cognito_client_application_id = cognito_config["tokenPool"]["appClientId"]
 
         # Make authentication request to AWS Cognito
-        cognito_idp_client = boto3.client("cognito-idp")
+        cognito_idp_client = boto3.client("cognito-idp", region_name="us-east-1")
         response = cognito_idp_client.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",
             AuthParameters={"USERNAME": self._api_token, "PASSWORD": self._api_secret},

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -76,6 +76,7 @@ class ClientSession(object):
         self._headers = settings.headers
         self._model_service_host = settings.model_service_host
         self._logger = log.get_logger("pennsieve.base.ClientSession")
+        self.aws_region_name = settings.aws_region_name
 
         self._session = None
         self._token = None
@@ -103,7 +104,9 @@ class ClientSession(object):
         cognito_client_application_id = cognito_config["tokenPool"]["appClientId"]
 
         # Make authentication request to AWS Cognito
-        cognito_idp_client = boto3.client("cognito-idp", region_name="us-east-1")
+        cognito_idp_client = boto3.client(
+            "cognito-idp", region_name=self.aws_region_name
+        )
         response = cognito_idp_client.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",
             AuthParameters={"USERNAME": self._api_token, "PASSWORD": self._api_secret},

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -76,7 +76,6 @@ class ClientSession(object):
         self._headers = settings.headers
         self._model_service_host = settings.model_service_host
         self._logger = log.get_logger("pennsieve.base.ClientSession")
-        self.aws_region_name = settings.aws_region_name
 
         self._session = None
         self._token = None
@@ -102,10 +101,11 @@ class ClientSession(object):
 
         cognito_config = self._get("/authentication/cognito-config")
         cognito_client_application_id = cognito_config["tokenPool"]["appClientId"]
+        cognito_region_name = cognito_config["region"]
 
         # Make authentication request to AWS Cognito
         cognito_idp_client = boto3.client(
-            "cognito-idp", region_name=self.aws_region_name
+            "cognito-idp", region_name=cognito_region_name
         )
         response = cognito_idp_client.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -45,8 +45,7 @@ class PennsieveRequest(object):
 
     def _handle_response(self, resp):
         self._logger.debug(u"resp = {}".format(resp))
-        self._logger.debug(u"resp.content = {}".format(
-            resp.text))  # decoded unicode
+        self._logger.debug(u"resp.content = {}".format(resp.text))  # decoded unicode
         if resp.status_code in [requests.codes.forbidden, requests.codes.unauthorized]:
             raise UnauthorizedException()
 
@@ -103,12 +102,9 @@ class ClientSession(object):
         # Make authentication request to AWS Cognito
         cognito_idp_client = boto3.client("cognito-idp")
         response = cognito_idp_client.initiate_auth(
-            AuthFlow='USER_PASSWORD_AUTH',
-            AuthParameters={
-                "USERNAME": self._api_token,
-                "PASSWORD": self._api_secret
-            },
-            ClientId=self._api_id
+            AuthFlow="USER_PASSWORD_AUTH",
+            AuthParameters={"USERNAME": self._api_token, "PASSWORD": self._api_secret},
+            ClientId=self._api_id,
         )
 
         # Ensures that `self._session` exists
@@ -120,8 +116,9 @@ class ClientSession(object):
 
         if organization is None:
             organization_node_id_jwt = response["AuthenticationResult"]["IdToken"]
-            organization_node_id = jwt.decode(organization_node_id_jwt, options={
-                "verify_signature": False})["custom:organization_node_id"]
+            organization_node_id = jwt.decode(
+                organization_node_id_jwt, options={"verify_signature": False}
+            )["custom:organization_node_id"]
             organization = organization_node_id
 
         self._set_org_context(organization)
@@ -154,8 +151,7 @@ class ClientSession(object):
         self._session.headers["X-ORGANIZATION-ID"] = organization_id
 
     def _set_auth(self, session_token):
-        self._session.headers["Authorization"] = "Bearer {}".format(
-            session_token)
+        self._session.headers["Authorization"] = "Bearer {}".format(session_token)
 
     @property
     def session(self):

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -46,8 +46,7 @@ class PennsieveRequest(object):
 
     def _handle_response(self, resp):
         self._logger.debug(u"resp = {}".format(resp))
-        self._logger.debug(u"resp.content = {}".format(
-            resp.text))  # decoded unicode
+        self._logger.debug(u"resp.content = {}".format(resp.text))  # decoded unicode
         if resp.status_code in [requests.codes.forbidden, requests.codes.unauthorized]:
             raise UnauthorizedException()
 
@@ -105,8 +104,7 @@ class ClientSession(object):
         cognito_idp_client = boto3.client("cognito-idp")
         response = cognito_idp_client.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",
-            AuthParameters={"USERNAME": self._api_token,
-                            "PASSWORD": self._api_secret},
+            AuthParameters={"USERNAME": self._api_token, "PASSWORD": self._api_secret},
             ClientId=self._api_id,
         )
 
@@ -157,8 +155,7 @@ class ClientSession(object):
         self._session.headers["X-ORGANIZATION-ID"] = organization_id
 
     def _set_auth(self, session_token):
-        self._session.headers["Authorization"] = "Bearer {}".format(
-            session_token)
+        self._session.headers["Authorization"] = "Bearer {}".format(session_token)
 
     @property
     def session(self):

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -72,7 +72,6 @@ class ClientSession(object):
         self._host = settings.api_host
         self._api_token = settings.api_token
         self._api_secret = settings.api_secret
-        self._api_id = settings.api_id
         self._jwt = settings.jwt
         self._headers = settings.headers
         self._model_service_host = settings.model_service_host
@@ -100,12 +99,16 @@ class ClientSession(object):
         subsequent API calls.
         """
 
+        cognito_config_response = self._get("/authentication/cognito-config")
+        cognito_config = cognito_config_response.json()
+        cognito_client_application_id = cognito_config["appClientId"]
+
         # Make authentication request to AWS Cognito
         cognito_idp_client = boto3.client("cognito-idp")
         response = cognito_idp_client.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",
             AuthParameters={"USERNAME": self._api_token, "PASSWORD": self._api_secret},
-            ClientId=self._api_id,
+            ClientId=cognito_client_application_id,
         )
 
         # Grab the tokens

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -99,9 +99,8 @@ class ClientSession(object):
         subsequent API calls.
         """
 
-        cognito_config_response = self._get("/authentication/cognito-config")
-        cognito_config = cognito_config_response.json()
-        cognito_client_application_id = cognito_config["appClientId"]
+        cognito_config = self._get("/authentication/cognito-config")
+        cognito_client_application_id = cognito_config["tokenPool"]["appClientId"]
 
         # Make authentication request to AWS Cognito
         cognito_idp_client = boto3.client("cognito-idp")

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -101,10 +101,13 @@ class ClientSession(object):
         """
 
         # Get the latest public jwks for our user pool
-        region = "us-east-1"
-        userpool_id = "us-east-1_7bX2Pm0zh"
-        jwks_url = 'https://cognito-idp.{}.amazonaws.com/{}/.well-known/jwks.json'.format(region, userpool_id)
-        jwks = requests.get(jwks_url).json()["keys"]
+        #
+        # TODO(jesse) These keys are used to verify the JWT
+        #
+        # region = "us-east-1"
+        # userpool_id = "us-east-1_7bX2Pm0zh"
+        # jwks_url = 'https://cognito-idp.{}.amazonaws.com/{}/.well-known/jwks.json'.format(region, userpool_id)
+        # jwks = requests.get(jwks_url).json()["keys"]
 
         # Make authentication request to AWS Cognito
         cognito_idp_client = boto3.client("cognito-idp")
@@ -118,22 +121,23 @@ class ClientSession(object):
         access_token_jwt = response["AuthenticationResult"]["AccessToken"]
         id_token_jwt = response["AuthenticationResult"]["IdToken"]
 
-        # Search for the kid in the downloaded public keys
-        headers = jwt.get_unverified_headers(id_token_jwt)
-        kid = headers["kid"]
-        key_index = list(map(lambda jwk: jwk["kid"], jwks)).index(kid)
-
         # Verify the token signatures
         #
         # TODO(jesse) Figure out why this check fails.
         #
+        # Search for the kid in the downloaded public keys
+        #
+        # headers = jwt.get_unverified_headers(id_token_jwt)
+        # kid = headers["kid"]
+        # key_index = list(map(lambda jwk: jwk["kid"], jwks)).index(kid)
         # public_key = jwk.construct(jwks[key_index])
+        #
         # for token in [access_token_jwt, id_token_jwt]:
         #     message, encoded_signature = str(token).rsplit('.', 1)
         #     decoded_signature = base64url_decode(encoded_signature.encode('utf-8'))
         #     if not public_key.verify(message.encode("utf8"), decoded_signature):
         #         raise ValueError("Signature verification failed")
-        
+
         # Since we passed the verification, we can now safely use the claims
         claims = jwt.get_unverified_claims(id_token_jwt)
 

--- a/pennsieve/client.py
+++ b/pennsieve/client.py
@@ -71,8 +71,8 @@ class Pennsieve(object):
 
     Note:
         To initialize your ``Pennsieve`` client without passing any arguments,
-        ensure that these environment variables are set: 
-        
+        ensure that these environment variables are set:
+
         - ``PENNSIEVE_API_ID``      (Client application ID for Cognito token pool)
         - ``PENNSIEVE_API_TOKEN``   (Username of your token pool credentials)
         - ``PENNSIEVE_API_SECRET``  (Password of your token pool credentials)

--- a/pennsieve/client.py
+++ b/pennsieve/client.py
@@ -73,7 +73,6 @@ class Pennsieve(object):
         To initialize your ``Pennsieve`` client without passing any arguments,
         ensure that these environment variables are set:
 
-        - ``PENNSIEVE_API_ID``      (Client application ID for Cognito token pool)
         - ``PENNSIEVE_API_TOKEN``   (Username of your token pool credentials)
         - ``PENNSIEVE_API_SECRET``  (Password of your token pool credentials)
 
@@ -89,7 +88,6 @@ class Pennsieve(object):
         host=None,
         model_service_host=None,
         env_override=True,
-        api_id=None,
         **overrides
     ):
 
@@ -102,7 +100,6 @@ class Pennsieve(object):
                     "api_token": api_token,
                     "api_secret": api_secret,
                     "api_host": host,
-                    "api_id": api_id,
                     "jwt": jwt,
                     "headers": headers,
                     "model_service_host": model_service_host,

--- a/pennsieve/client.py
+++ b/pennsieve/client.py
@@ -71,8 +71,11 @@ class Pennsieve(object):
 
     Note:
         To initialize your ``Pennsieve`` client without passing any arguments,
-        ensure that your ``PENNSIEVE_API_TOKEN`` and ``PENNSIEVE_API_SECRET`` environment variables
-        are properly set.
+        ensure that these environment variables are set: 
+        
+        - ``PENNSIEVE_API_ID``      (Client application ID for Cognito token pool)
+        - ``PENNSIEVE_API_TOKEN``   (Username of your token pool credentials)
+        - ``PENNSIEVE_API_SECRET``  (Password of your token pool credentials)
 
     """
 
@@ -86,6 +89,7 @@ class Pennsieve(object):
         host=None,
         model_service_host=None,
         env_override=True,
+        api_id=None,
         **overrides
     ):
 
@@ -98,6 +102,7 @@ class Pennsieve(object):
                     "api_token": api_token,
                     "api_secret": api_secret,
                     "api_host": host,
+                    "api_id": api_id,
                     "jwt": jwt,
                     "headers": headers,
                     "model_service_host": model_service_host,

--- a/pennsieve/config.py
+++ b/pennsieve/config.py
@@ -155,6 +155,8 @@ DEFAULTS = {
     # pennsieve api locations
     "api_host": "https://api.pennsieve.io",
     "model_service_host": None,
+    # Pennsieve AWS Cognito Client Application ID
+    "api_id": None,
     # pennsieve API token/secret
     "api_token": None,
     "api_secret": None,
@@ -185,6 +187,7 @@ DEFAULTS = {
 
 ENVIRONMENT_VARIABLES = {
     "api_host": ("PENNSIEVE_API_LOC", str),
+    "api_id": ("PENNSIEVE_API_ID", str),
     "api_token": ("PENNSIEVE_API_TOKEN", str),
     "api_secret": ("PENNSIEVE_API_SECRET", str),
     "jwt": ("PENNSIEVE_JWT", str),
@@ -273,7 +276,7 @@ class Settings(object):
         if "global" in self.config:
             self._parse_profile("global")
         for name in self.config.sections():
-            if name is not "global":
+            if name != "global":
                 self.profiles[name] = self.profiles["global"].copy()
                 self._parse_profile(name)
 
@@ -298,7 +301,7 @@ class Settings(object):
         else:
             self.__dict__.update(self.profiles[name])
             self.active_profile = name
-            if name is "global":
+            if name == "global":
                 self.active_profile = None
 
     @property

--- a/pennsieve/config.py
+++ b/pennsieve/config.py
@@ -156,7 +156,6 @@ DEFAULTS = {
     "api_host": "https://api.pennsieve.io",
     "model_service_host": None,
     # Pennsieve AWS Cognito Client Application ID
-    "api_id": None,
     # pennsieve API token/secret
     "api_token": None,
     "api_secret": None,
@@ -187,7 +186,6 @@ DEFAULTS = {
 
 ENVIRONMENT_VARIABLES = {
     "api_host": ("PENNSIEVE_API_LOC", str),
-    "api_id": ("PENNSIEVE_API_ID", str),
     "api_token": ("PENNSIEVE_API_TOKEN", str),
     "api_secret": ("PENNSIEVE_API_SECRET", str),
     "jwt": ("PENNSIEVE_JWT", str),

--- a/pennsieve/config.py
+++ b/pennsieve/config.py
@@ -159,8 +159,6 @@ DEFAULTS = {
     # pennsieve API token/secret
     "api_token": None,
     "api_secret": None,
-    # AWS Region
-    "aws_region_name": "us-east-1",
     # pennsieve JWT
     "jwt": None,
     # global headers
@@ -190,7 +188,6 @@ ENVIRONMENT_VARIABLES = {
     "api_host": ("PENNSIEVE_API_LOC", str),
     "api_token": ("PENNSIEVE_API_TOKEN", str),
     "api_secret": ("PENNSIEVE_API_SECRET", str),
-    "aws_region_name": ("AWS_REGION_NAME", str),
     "jwt": ("PENNSIEVE_JWT", str),
     "pennsieve_dir": ("PENNSIEVE_LOCAL_DIR", str),
     "cache_dir": ("PENNSIEVE_CACHE_LOC", str),

--- a/pennsieve/config.py
+++ b/pennsieve/config.py
@@ -159,6 +159,8 @@ DEFAULTS = {
     # pennsieve API token/secret
     "api_token": None,
     "api_secret": None,
+    # AWS Region
+    "aws_region_name": "us-east-1",
     # pennsieve JWT
     "jwt": None,
     # global headers
@@ -188,6 +190,7 @@ ENVIRONMENT_VARIABLES = {
     "api_host": ("PENNSIEVE_API_LOC", str),
     "api_token": ("PENNSIEVE_API_TOKEN", str),
     "api_secret": ("PENNSIEVE_API_SECRET", str),
+    "aws_region_name": ("AWS_REGION_NAME", str),
     "jwt": ("PENNSIEVE_JWT", str),
     "pennsieve_dir": ("PENNSIEVE_LOCAL_DIR", str),
     "cache_dir": ("PENNSIEVE_CACHE_LOC", str),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto3
 configparser>=3.5
 deprecated>=1.2.0
 future>=0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
-pytz>=2016
-requests>=2.18
-protobuf>=3.2.0
 configparser>=3.5
+deprecated>=1.2.0
 future>=0.15.0
 futures
-deprecated>=1.2.0
+protobuf>=3.2.0
+pyjwt==2.0.1
+pytz>=2016
+requests>=2.18
 semver>=2.8.0
 websocket-client>=0.57.0
+
 # CLI
 docopt>=0.6
 psutil>=5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ deprecated>=1.2.0
 future>=0.15.0
 futures
 protobuf>=3.2.0
-pyjwt==2.0.1
+python-jose==3.2.0
 pytz>=2016
 requests>=2.18
 semver>=2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ protobuf>=3.2.0
 python-jose==3.2.0
 pytz>=2016
 requests>=2.18
+rsa==4.0
 semver>=2.8.0
 websocket-client>=0.57.0
 


### PR DESCRIPTION
# Description

Authenticates through Cognito and uses information in the return JWTs to maintain a Pennsieve session.

- Adds an extra configuration setting, client users must now provide the AWS Cognito client application ID.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran existing tests, which all use a client authenticated through Cognito.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
