### PR TITLE
Add a platform check for windows

### DIFF
--- a/pennsieve/api/agent.py
+++ b/pennsieve/api/agent.py
@@ -4,6 +4,7 @@ from future.utils import raise_from
 import errno
 import json
 import os
+import platform
 import socket
 import subprocess
 import sys
@@ -148,6 +149,8 @@ def check_port(port):
 
 
 def socket_address(port):
+    if platform.system() == "Windows":
+        return "ws://127.0.0.1:{}".format(port)
     return "ws://0.0.0.0:{}".format(port)
 
 


### PR DESCRIPTION
# Description

Addresses issue where agent's socket address was invalid on Windows.

```
addrinfo_list = [(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('0.0.0.0', 11235))], sockopt = [], timeout = None

    def _open_socket(addrinfo_list, sockopt, timeout):
        err = None
        for addrinfo in addrinfo_list:
            family, socktype, proto = addrinfo[:3]
            sock = socket.socket(family, socktype, proto)
            sock.settimeout(timeout)
            for opts in DEFAULT_SOCKET_OPTION:
                sock.setsockopt(*opts)
            for opts in sockopt:
                sock.setsockopt(*opts)

            address = addrinfo[4]
            err = None
            while not err:
                try:
>                   sock.connect(address)
E                   OSError: [WinError 10049] The requested address is not valid in its context
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Confirmed tests passing on the following platforms

```
- Windows 10
- Linux Mint 19
- macOS Catalina
```
