### PR TITLE
Fix Cognito login for clients with no AWS creds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Documentation at <https://developer.pennsieve.io/python/>
 
+
+## 6.1.2
+
+### Fixed
+- Authentication with Cognito when a user does not have AWS credentials configured
+- Fixed connection to the Agent websocket on Windows
+
 ## 6.1.1
 
 ### Fixed

--- a/pennsieve/__init__.py
+++ b/pennsieve/__init__.py
@@ -27,4 +27,4 @@ from .models import (
 )
 
 __title__ = "pennsieve"
-__version__ = "6.1.1"
+__version__ = "6.1.2"

--- a/pennsieve/base.py
+++ b/pennsieve/base.py
@@ -88,11 +88,11 @@ class ClientSession(object):
     def authenticate(self, organization=None):
         """"""
         if self._jwt is None:
-            self._authenticate_with_session(organization=organization)
+            self._authenticate_with_cognito(organization=organization)
         else:
             self._authenticate_with_jwt()
 
-    def _authenticate_with_session(self, organization=None):
+    def _authenticate_with_cognito(self, organization=None):
         """
         An API token is used to authenticate against the Pennsieve platform.
         The token that is returned from the API call will be used for all
@@ -103,9 +103,17 @@ class ClientSession(object):
         cognito_client_application_id = cognito_config["tokenPool"]["appClientId"]
         cognito_region_name = cognito_config["region"]
 
-        # Make authentication request to AWS Cognito
+        # Authenticate to AWS Cognito
+        #
+        # Hack: stub the access and secret keys with empty values so boto does
+        # not look for AWS credentials in the environment. Some versions of boto
+        # fail when they cannot find AWS credentials even though Cognito does
+        # not need creds.
         cognito_idp_client = boto3.client(
-            "cognito-idp", region_name=cognito_region_name
+            "cognito-idp",
+            region_name=cognito_region_name,
+            aws_access_key_id="",
+            aws_secret_access_key="",
         )
         response = cognito_idp_client.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",


### PR DESCRIPTION

# Description

Stub the access and secret keys with empty values so boto does not look
for AWS credentials in the environment. Some older versions of boto fail
when they cannot find AWS credentials even though Cognito does now need
AWS access to work.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Installed the following boto versions to verify broken behavior:

```
pip install boto3==1.11.14 botocore==1.14.14 boto=2.49.0
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
