### PR TITLE
Filter out .DS_STORE when uploading

### DIFF
--- a/pennsieve/__init__.py
+++ b/pennsieve/__init__.py
@@ -27,4 +27,4 @@ from .models import (
 )
 
 __title__ = "pennsieve"
-__version__ = "6.1.1"
+__version__ = "6.1.3"

--- a/pennsieve/api/agent.py
+++ b/pennsieve/api/agent.py
@@ -221,11 +221,6 @@ def agent_upload(
     # Agent uses absolute paths
     expected_files = [os.path.abspath(f) for f in expected_files]
 
-    # Filter out .DS_STORE files
-    expected_files = [
-        f for f in expected_files if os.path.split(f)[-1].lower() != ".ds_store"
-    ]
-
     if isinstance(destination, Dataset):
         dataset_id = destination.id
         package_id = None

--- a/pennsieve/api/agent.py
+++ b/pennsieve/api/agent.py
@@ -221,6 +221,11 @@ def agent_upload(
     # Agent uses absolute paths
     expected_files = [os.path.abspath(f) for f in expected_files]
 
+    # Filter out .DS_STORE files
+    expected_files = [
+        f for f in expected_files if os.path.split(f)[-1].lower() != ".ds_store"
+    ]
+
     if isinstance(destination, Dataset):
         dataset_id = destination.id
         package_id = None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,6 +22,7 @@ FILE4 = _resource_path("test-78f3ea50-b.txt")
 FILE_EMPTY = _resource_path("test-78f3ea50.empty")
 FLAT_DIR = _resource_path("flat_dir")
 NESTED_DIR = _resource_path("nested_dir")
+DSTORE_DIR = _resource_path("dstore_dir")
 INNER_DIR = "inner_dir"
 
 
@@ -102,6 +103,13 @@ def test_upload_recursive_flag_is_not_allowed_with_file(dataset):
 def test_upload_cannot_upload_multiple_directories(dataset):
     with pytest.raises(AgentError):
         dataset.upload(FLAT_DIR, FILE1)
+
+
+@pytest.mark.agent
+def test_upload_directory_with_dstore_file(dataset):
+    collection = dataset.create_collection(str(uuid.uuid4()))
+    collection.upload(DSTORE_DIR, recursive=True)
+    assert len(collection.items) == 1
 
 
 @pytest.mark.agent


### PR DESCRIPTION
# Description

Fixes an issue where upload hangs because the python client attempts to ask the agent to upload a `.DS_STORE` file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

A test case has been added which reproduced the bug by attempting to upload a folder containing `.DS_STORE`.

###  Bug Description

>Pennsieve Agent and Pennsieve Python issue with .DS_STORE files: When trying to upload a folder in python from macOS that already has a .DS_STORE file in the folder causes the upload to freeze. If this folder is being uploaded via the agent, it skips over any .DS_STORE files but when sending the same folder via python calls, the agent gets stuck on a waiting on queue message. Attaching the log files for this process here.

![image](https://user-images.githubusercontent.com/9408481/115447342-668d0500-a1e6-11eb-9879-4e10ea41b420.png)
