### PR TITLE
update requirements.txt to prevent install fail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3
 configparser>=3.5
 deprecated>=1.2.0
 future>=0.15.0
-futures
+futures; python_version < '3.0'
 protobuf>=3.2.0,<=3.20.1
 python-jose==3.2.0
 pytz>=2016


### PR DESCRIPTION
# Description
The pypi futures https://pypi.org/project/futures/ package uses syntax that is not compatible with python3 which makes it impossible to install pennsieve python via pip on any version of python3.

This change fixes that by restricting futures to only be installed on python2.

A new release to pypi is needed following this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update